### PR TITLE
Added a slider to adjust the screen size

### DIFF
--- a/Pinetree.Client/Pages/Components/Markdown.razor
+++ b/Pinetree.Client/Pages/Components/Markdown.razor
@@ -324,7 +324,6 @@
         ViewMode = mode;
         StateHasChanged();
 
-        await Task.Delay(10);
         await JS.InvokeVoidAsync("initResizers");
     }
 

--- a/Pinetree.Client/Pages/Components/Markdown.razor
+++ b/Pinetree.Client/Pages/Components/Markdown.razor
@@ -5,181 +5,193 @@
 
 @implements IAsyncDisposable
 
-<div class="editor-container">
+<div class="resizable-page">
     @if (IsTry)
     {
-        <div class="row">
-            <div class="col">
-                <div class="alert alert-primary" role="alert">
-                    <i class="bi bi-info-circle-fill"></i>
-                    If you want to create multiple files, please <a href="Account/Register" class="alert-link">register</a>.
-                </div>
+        <div class="description-bar">
+            <div class="alert alert-primary" role="alert">
+                <i class="bi bi-info-circle-fill"></i>
+                If you want to create multiple files, please <a href="Account/Register" class="alert-link">register</a>.
             </div>
         </div>
     }
-    <div class="row">
-        @if (IsSidebarOpen)
-        {
-            <div class="col-2 border">
-                <div class="pinetree-view" style="display: flex; flex-direction: column; height: 100%;">
-                    <div class="list-group" style="flex: 1 1 auto; display: flex; flex-direction: column;">
-                        @if (!IsTry)
-                        {
-                            <div>
-                                <button type="button" class="list-group-item list-group-item-action" @onclick="OnFileListClick">
-                                    <i class="bi bi-card-list" aria-hidden="true"></i> File List
+    <div class="panels-section">
+        <div class="panels-row">
+            <div id="panel1" class="panel">
+                <div class="panel-content-wrapper">
+                    <div class="panel-header">
+                    </div>
+                    <div class="panel-content">
+                        <div>
+                            <div class="pinetree-view">
+                                <div class="list-group">
+                                    @if (!IsTry)
+                                    {
+                                        <div>
+                                            <button type="button" class="list-group-item list-group-item-action" @onclick="OnFileListClick">
+                                                <i class="bi bi-card-list" aria-hidden="true"></i> File List
+                                            </button>
+                                        </div>
+                                    }
+                                    <div>
+                                        <TreeView Pinetree="@Pinetree" Guid="@Guid" IsTry=@IsTry IsProfessional=IsProfessional OnChildEvent="SetCurrent" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel-footer">
+                        <div>
+                            FileCount : @FileCount
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="resizer" id="resizer1"></div>
+
+            <div class="right-panels">
+                <div class="common-header">
+                    <div class="markdown-title d-flex align-items-center">
+                        <input @bind="@(Title)" @oninput="OnInputTitleChange" placeholder="Untitled" class="mx-1 flex-grow-1" />
+                        <div class="d-flex align-items-center ms-2">
+                            <button @onclick="SaveChanges" disabled="@(!HasPendingChanges() || IsTry || _isSaving)"
+                                    class="btn btn-sm btn-primary me-2" title="Save changes">
+                                @if (_isSaving)
+                                {
+                                    <span class="d-flex align-items-center">
+                                        <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                                        <span>Saving...</span>
+                                    </span>
+                                }
+                                else
+                                {
+                                    <span class="d-flex align-items-center">
+                                        <i class="bi bi-save me-1"></i>
+                                        <span>Save</span>
+                                    </span>
+                                }
+                            </button>
+                        </div>
+                    </div>
+                    <div class="toolbar bg-light border-bottom d-flex align-items-center p-1">
+                        <div class="btn-toolbar" role="toolbar" aria-label="Markdown editing toolbar">
+                            <div class="btn-group me-2" role="group" aria-label="Special actions">
+                                <button type="button" class="btn btn-sm btn-outline-success" title="Move selected text to child file" @onclick="ExtractToChildFile">
+                                    <i class="bi bi-file-earmark-arrow-down"></i> Extract to Child
                                 </button>
                             </div>
-                        }
-                        <div>
-                            <TreeView Pinetree="@Pinetree" Guid="@Guid" IsTry=@IsTry IsProfessional=IsProfessional OnChildEvent="SetCurrent" />
+                            <div class="btn-group me-2" role="group" aria-label="Undo/Redo">
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Undo (Ctrl+Z)" @onclick="UndoAsync" disabled="@(!CanUndo)">
+                                    <i class="bi bi-arrow-counterclockwise"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Redo (Ctrl+Y)" @onclick="RedoAsync" disabled="@(!CanRedo)">
+                                    <i class="bi bi-arrow-clockwise"></i>
+                                </button>
+                            </div>
+                            <div class="btn-group me-2" role="group" aria-label="Text formatting">
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Bold" @onclick='() => FormatText("**", "**")'>
+                                    <i class="bi bi-type-bold"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Italic" @onclick='() => FormatText("*", "*" )'>
+                                    <i class="bi bi-type-italic"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Strikethrough" @onclick='() => FormatText("~~", "~~" )'>
+                                    <i class="bi bi-type-strikethrough"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Heading" @onclick='() => InsertList("# ")'>
+                                    <i class="bi bi-type-h1"></i>
+                                </button>
+                            </div>
+                            <div class="btn-group me-2" role="group" aria-label="List formatting">
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Bullet List" @onclick='() => InsertList("- ")'>
+                                    <i class="bi bi-list-ul"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Numbered List" @onclick='() => InsertList("1. ")'>
+                                    <i class="bi bi-list-ol"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Check List" @onclick='() => InsertList("- [ ] ")'>
+                                    <i class="bi bi-check-square"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Insert Code Block" @onclick='() => FormatText("```\n", "\n```" )'>
+                                    <i class="bi bi-code-slash"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Quotation" @onclick='() => InsertList("> ")'>
+                                    <i class="bi bi-quote"></i>
+                                </button>
+                            </div>
+                            <div class="btn-group me-2" role="group" aria-label="Insert elements">
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Insert Link" @onclick='InsertLink'>
+                                    <i class="bi bi-link-45deg"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Insert Image" @onclick="InsertImage">
+                                    <i class="bi bi-image"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Insert Grid" @onclick="InsertGrid">
+                                    <i class="bi bi-grid-3x2"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm btn-outline-dark" title="Insert Line" @onclick="InsertLine">
+                                    <i class="bi bi-dash"></i>
+                                </button>
+                            </div>
+                            <div class="btn-group ms-2" role="group" aria-label="View mode">
+                                <button type="button" class="btn btn-sm @(ViewMode == "split" ? "btn-primary" : "btn-outline-secondary")"
+                                        @onclick='() => SetViewMode("split")' title="Split view">
+                                    <i class="bi bi-layout-split"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm @(ViewMode == "edit" ? "btn-primary" : "btn-outline-secondary")"
+                                        @onclick='() => SetViewMode("edit")' title="Edit only">
+                                    <i class="bi bi-pencil-square"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm @(ViewMode == "preview" ? "btn-primary" : "btn-outline-secondary")"
+                                        @onclick='() => SetViewMode("preview")' title="Preview only">
+                                    <i class="bi bi-eye"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="btn-group ms-auto" role="group" aria-label="Id actions">
+                            <button @onclick="CopyDocumentId" class="btn btn-sm btn-outline-secondary" title="@(_copyIconState ? "Copied!" : $"Click to copy {Current.Guid}")">
+                                <span class="d-flex align-items-center">
+                                    <i class="@(_copyIconState ? "bi bi-check-lg" : "bi bi-clipboard")" style="transition: all 0.3s"></i>
+                                    <small class="ms-1">ID: @($"{Current.Guid.ToString()[..8]}...")</small>
+                                </span>
+                            </button>
+                        </div>
+                        <i class="bi bi-question-circle ms-1 p-1 text-body" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-custom-class="custom-tooltip"
+                           title="<strong>Document ID</strong><br>This unique identifier can be used to reference this document in markdown links.<br>Format: [link text](//ID)"></i>
+                    </div>
+                </div>
+                <div class="right-panels-container">
+                    <div id="panel2" class="panel"
+                         style="display: @(ViewMode == "edit" || ViewMode == "split" ? "flex" : "none");
+                            @(ViewMode == "edit" ? "flex: 1 !important; width: 100% !important;" : "")">
+                        <div class="panel-content-wrapper">
+                            <div class="panel-content">
+                                <textarea @ref="TextAreaRef" @bind="@(Content)" class="no-resize"
+                                          style="width:100%; height:99%; padding-bottom: 50vh; box-sizing: border-box;"
+                                          @oninput="OnInputChange" placeholder="Write your markdown here..."></textarea>
+                            </div>
+                            <div class="panel-footer">
+                                <div class="counter">@Content.Length characters</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="resizer" id="resizer2" style="display: @(ViewMode == "split" ? "block" : "none")"></div>
+                    <div id="panel3" class="panel" style="display: @(ViewMode == "preview" || ViewMode == "split" ? "flex" : "none")">
+                        <div class="panel-content-wrapper">
+                            <div class="panel-content">
+                                <div @ref="MarkdownContainer"
+                                     class="border"
+                                     style="width:100%; height:99%; overflow:auto;">
+                                    @((MarkupString)MarkdownText)
+                                </div>
+                            </div>
+                            <div class="panel-footer">
+                                <div class="counter">-</div>
+                            </div>
                         </div>
                     </div>
                 </div>
-                <div class="py-2">
-                    FileCount : @FileCount
-                </div>
-            </div>
-        }
-        <div class="@(IsSidebarOpen ? "col-10" : "col-12")" style="transition: margin-left 0.3s ease-in-out;">
-            @if (IsSidebarOpen)
-            {
-                <button class="btn btn-sm btn-secondary tree-toggle" @onclick="ToggleSidebar">
-                    <i class="bi bi-chevron-left"></i>
-                </button>
-            }
-            else
-            {
-                <button class="btn btn-sm btn-outline-secondary tree-toggle" @onclick="ToggleSidebar">
-                    <i class="bi bi-chevron-right"></i>
-                </button>
-            }
-            <div class="markdown-title d-flex align-items-center">
-                <input @bind="@(Title)" @oninput="OnInputTitleChange" placeholder="Untitled" class="flex-grow-1" />
-                <div class="d-flex align-items-center ms-2">
-                    <button @onclick="SaveChanges" disabled="@(!HasPendingChanges() || IsTry || _isSaving)"
-                            class="btn btn-sm btn-primary me-2" title="Save changes">
-                        @if (_isSaving)
-                        {
-                            <span class="d-flex align-items-center">
-                                <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
-                                <span>Saving...</span>
-                            </span>
-                        }
-                        else
-                        {
-                            <span class="d-flex align-items-center">
-                                <i class="bi bi-save me-1"></i>
-                                <span>Save</span>
-                            </span>
-                        }
-                    </button>
-                </div>
-            </div>
-            <div class="toolbar p-2 bg-light border-bottom d-flex align-items-center mb-2">
-                <div class="btn-toolbar" role="toolbar" aria-label="Markdown editing toolbar">
-                    <div class="btn-group me-2" role="group" aria-label="Special actions">
-                        <button type="button" class="btn btn-sm btn-outline-success" title="Move selected text to child file" @onclick="ExtractToChildFile">
-                            <i class="bi bi-file-earmark-arrow-down"></i> Extract to Child
-                        </button>
-                    </div>
-                    <div class="btn-group me-2" role="group" aria-label="Undo/Redo">
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Undo (Ctrl+Z)" @onclick="UndoAsync" disabled="@(!CanUndo)">
-                            <i class="bi bi-arrow-counterclockwise"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Redo (Ctrl+Y)" @onclick="RedoAsync" disabled="@(!CanRedo)">
-                            <i class="bi bi-arrow-clockwise"></i>
-                        </button>
-                    </div>
-                    <div class="btn-group me-2" role="group" aria-label="Text formatting">
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Bold" @onclick='() => FormatText("**", "**")'>
-                            <i class="bi bi-type-bold"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Italic" @onclick='() => FormatText("*", "*" )'>
-                            <i class="bi bi-type-italic"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Strikethrough" @onclick='() => FormatText("~~", "~~" )'>
-                            <i class="bi bi-type-strikethrough"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Heading" @onclick='() => InsertList("# ")'>
-                            <i class="bi bi-type-h1"></i>
-                        </button>
-                    </div>
-                    <div class="btn-group me-2" role="group" aria-label="List formatting">
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Bullet List" @onclick='() => InsertList("- ")'>
-                            <i class="bi bi-list-ul"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Numbered List" @onclick='() => InsertList("1. ")'>
-                            <i class="bi bi-list-ol"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Check List" @onclick='() => InsertList("- [ ] ")'>
-                            <i class="bi bi-check-square"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Insert Code Block" @onclick='() => FormatText("```\n", "\n```" )'>
-                            <i class="bi bi-code-slash"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Quotation" @onclick='() => InsertList("> ")'>
-                            <i class="bi bi-quote"></i>
-                        </button>
-                    </div>
-                    <div class="btn-group me-2" role="group" aria-label="Insert elements">
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Insert Link" @onclick='InsertLink'>
-                            <i class="bi bi-link-45deg"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Insert Image" @onclick="InsertImage">
-                            <i class="bi bi-image"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Insert Grid" @onclick="InsertGrid">
-                            <i class="bi bi-grid-3x2"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm btn-outline-dark" title="Insert Line" @onclick="InsertLine">
-                            <i class="bi bi-dash"></i>
-                        </button>
-                    </div>
-                    <div class="btn-group ms-2" role="group" aria-label="View mode">
-                        <button type="button" class="btn btn-sm @(ViewMode == "split" ? "btn-primary" : "btn-outline-secondary")"
-                        @onclick='() => SetViewMode("split")' title="Split view">
-                            <i class="bi bi-layout-split"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm @(ViewMode == "edit" ? "btn-primary" : "btn-outline-secondary")"
-                        @onclick='() => SetViewMode("edit")' title="Edit only">
-                            <i class="bi bi-pencil-square"></i>
-                        </button>
-                        <button type="button" class="btn btn-sm @(ViewMode == "preview" ? "btn-primary" : "btn-outline-secondary")"
-                        @onclick='() => SetViewMode("preview")' title="Preview only">
-                            <i class="bi bi-eye"></i>
-                        </button>
-                    </div>
-                </div>
-                <div class="btn-group ms-auto" role="group" aria-label="Id actions">
-                    <button @onclick="CopyDocumentId" class="btn btn-sm btn-outline-secondary" title="@(_copyIconState ? "Copied!" : $"Click to copy {Current.Guid}")">
-                        <span class="d-flex align-items-center">
-                            <i class="@(_copyIconState ? "bi bi-check-lg" : "bi bi-clipboard")" style="transition: all 0.3s"></i>
-                            <small class="ms-1">ID: @($"{Current.Guid.ToString()[..8]}...")</small>
-                        </span>
-                    </button>
-                    <i class="bi bi-question-circle ms-1 p-1" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-custom-class="custom-tooltip"
-                    title="<strong>Document ID</strong><br>This unique identifier can be used to reference this document in markdown links.<br>Format: [link text](//ID)"></i>
-                </div>
-            </div>
-            <div class="row" style="height:@(IsTry ? "80vh" : "87vh");">
-                @if (ViewMode == "edit" || ViewMode == "split")
-                {
-                    <div class="col py-2">
-                    <textarea @ref="TextAreaRef" @bind="@(Content)" class="no-resize"
-                              style="width:100%; height:101%; overflow:auto; padding-bottom: 50vh;"
-                              @oninput="OnInputChange" placeholder="Write your markdown here..."></textarea>
-                        <div class="counter">@Content.Length characters</div>
-                    </div>
-                }
-                @if (ViewMode == "preview" || ViewMode == "split")
-                {
-                    <div class="col py-2" style="height: 100%; overflow: hidden;">
-                        <div class="border markdown-body" style="width:100%; height:101%; overflow:auto;" @ref="MarkdownContainer">
-                            @((MarkupString)MarkdownText)
-                        </div>
-                    </div>
-                }
             </div>
         </div>
     </div>
@@ -245,6 +257,8 @@
             objRef = DotNetObjectReference.Create(this);
             await _jsInterop.SetupAllEventListenersAsync(MarkdownContainer, TextAreaRef, objRef);
             await _jsInterop.ClearAllImagesFromIndexedDB();
+
+            await JS.InvokeVoidAsync("initResizers");
         }
     }
 
@@ -305,10 +319,13 @@
         UpdateContent(content);
     }
 
-    private void SetViewMode(string mode)
+    private async Task SetViewMode(string mode)
     {
         ViewMode = mode;
         StateHasChanged();
+
+        await Task.Delay(10);
+        await JS.InvokeVoidAsync("initResizers");
     }
 
     private async ValueTask OnLocationChanging(LocationChangingContext context)

--- a/Pinetree.Client/Pages/Components/Markdown.razor.css
+++ b/Pinetree.Client/Pages/Components/Markdown.razor.css
@@ -56,7 +56,7 @@
     top: 3.5rem;
     left: 0;
     width: 100vw;
-    height: calc(100vh - 3.5rem);
+    height: 100%;
     margin: 0;
     padding: 0;
     overflow: hidden;

--- a/Pinetree.Client/Pages/Components/Markdown.razor.css
+++ b/Pinetree.Client/Pages/Components/Markdown.razor.css
@@ -47,3 +47,121 @@
     opacity: 0.65;
     cursor: not-allowed;
 }
+
+/**/
+.resizable-page {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 3.5rem;
+    left: 0;
+    width: 100vw;
+    height: calc(100vh - 3.5rem);
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+
+.description-bar {
+    position: relative;
+    width: 100%;
+    box-sizing: border-box;
+    flex-shrink: 0;
+    z-index: 10;
+    min-height: 40px;
+}
+
+.panels-section {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    overflow: hidden;
+}
+
+.panels-row {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    height: 100%;
+}
+
+.panel {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 100px;
+    overflow: hidden;
+    position: relative;
+    box-sizing: border-box;
+}
+
+#panel1 {
+    flex: 0 0 16%;
+    width: 16%;
+}
+
+.panel-content-wrapper {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+}
+
+.panel-header {
+    text-align: center;
+    flex-shrink: 0;
+    border-bottom: 1px solid #ccc;
+    z-index: 5;
+}
+
+.panel-content {
+    flex: 1;
+    overflow: auto;
+    padding: 10px;
+    box-sizing: border-box;
+}
+
+.panel-footer {
+    padding: 1px;
+    text-align: center;
+    flex-shrink: 0;
+    border-top: 1px solid #ccc;
+    z-index: 5;
+}
+
+.right-panels {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.common-header {
+    color: white;
+    padding: 1px;
+    text-align: center;
+    flex-shrink: 0;
+    z-index: 5;
+}
+
+.right-panels-container {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
+.resizer {
+    width: 6px;
+    height: 100%;
+    background-color: #ddd;
+    cursor: col-resize;
+    transition: background-color 0.2s;
+    flex-shrink: 0;
+    z-index: 20;
+}
+
+    .resizer:hover, .resizer.resizing {
+        background-color: #aaa;
+    }

--- a/Pinetree/Components/App.razor
+++ b/Pinetree/Components/App.razor
@@ -18,6 +18,7 @@
 <body>
     <Routes />
     <script src="_framework/blazor.web.js"></script>
+    <script src="resizablePanels.js"></script>
     <script src="@Assets["lib/bootstrap/dist/js/bootstrap.bundle.min.js"]" defer></script>
 </body>
 

--- a/Pinetree/wwwroot/resizablePanels.js
+++ b/Pinetree/wwwroot/resizablePanels.js
@@ -13,6 +13,7 @@
     
     if (!resizer2 || !panel2) {
         console.error("Required elements not found for resizer2");
+        return;
     }
     
     function setupResizer(resizer, targetPanel, minPercent, maxPercent) {

--- a/Pinetree/wwwroot/resizablePanels.js
+++ b/Pinetree/wwwroot/resizablePanels.js
@@ -1,0 +1,71 @@
+﻿window.initResizers = function () {
+    console.log("Initializing resizers...");
+    
+    const resizer1 = document.getElementById('resizer1');
+    const resizer2 = document.getElementById('resizer2');
+    const panel1 = document.getElementById('panel1');
+    const panel2 = document.getElementById('panel2');
+    
+    if (!resizer1 || !panel1) {
+        console.error("Required elements not found for resizer1");
+        return;
+    }
+    
+    if (!resizer2 || !panel2) {
+        console.error("Required elements not found for resizer2");
+    }
+    
+    function setupResizer(resizer, targetPanel, minPercent, maxPercent) {
+        let startX, startWidth, parentWidth;
+        
+        function onMouseDown(e) {
+            e.preventDefault();
+            startX = e.pageX;
+            const rect = targetPanel.getBoundingClientRect();
+            startWidth = rect.width;
+            parentWidth = targetPanel.parentNode.getBoundingClientRect().width;
+            
+            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mouseup', onMouseUp);
+            resizer.classList.add('resizing');
+            
+            document.body.style.cursor = 'col-resize';
+            document.body.style.userSelect = 'none';
+        }
+        
+        function onMouseMove(e) {
+            const dx = e.pageX - startX;
+            let newWidth = (startWidth + dx);
+            
+            const minWidth = parentWidth * (minPercent / 100);
+            const maxWidth = parentWidth * (maxPercent / 100);
+            
+            if (newWidth < minWidth) newWidth = minWidth;
+            if (newWidth > maxWidth) newWidth = maxWidth;
+            
+            const newWidthPercent = (newWidth / parentWidth) * 100;
+            
+            targetPanel.style.flex = `0 0 ${newWidthPercent}%`;
+            targetPanel.style.width = `${newWidthPercent}%`;
+        }
+        
+        function onMouseUp() {
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+            resizer.classList.remove('resizing');
+            
+            document.body.style.cursor = '';
+            document.body.style.userSelect = '';
+        }
+        
+        resizer.addEventListener('mousedown', onMouseDown);
+    }
+    
+    setupResizer(resizer1, panel1, 10, 50);
+    
+    if (resizer2 && panel2) {
+        setupResizer(resizer2, panel2, 10, 90);
+    }
+    
+    console.log("Resizers initialized successfully");
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a resizable, multi-panel layout for the markdown editor, allowing users to adjust panel widths via draggable dividers.
  - Added a new button to easily copy the document ID, with an explanatory tooltip.
  - Sidebar now displays a footer with the file count.

- **Refactor**
  - Updated the editor interface with a reorganized toolbar, improved panel structure, and a unified header for better usability.
  - Enhanced layout with clearer separation of editor, preview, and sidebar panels.

- **Style**
  - Applied new CSS for flexible, resizable panels and improved visual organization, including updated headers, footers, and resizer handles.

- **Chores**
  - Integrated a new script to support interactive panel resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->